### PR TITLE
MSI: Fix MSYS2 version to 20200522.0.0

### DIFF
--- a/td-agent/msi/Dockerfile
+++ b/td-agent/msi/Dockerfile
@@ -26,7 +26,7 @@ RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -I
 # Install toolchain
 RUN \
   choco install -y git wixtoolset 7zip && \
-  choco install -y msys2 --params /NoUpdate && \
+  choco install -y msys2 --params /NoUpdate --version=20200522.0.0 && \
   choco install -y ruby && \
   refreshenv && \
   ridk install 3


### PR DESCRIPTION
It avoids the following error on building Window container
with MSYS2 20200602.0.0:

re-exec error: exit status 1: output: time="2020-06-04T02:31:07Z" level=error msg="hcsshim::ImportLayer - failed failed in Win32: The system cannot find the path specified. (0x3)" error="hcsshim::ImportLayer - failed failed in Win32: The system cannot find the path specified. (0x3)" importFolderPath="C:\\ProgramData\\docker\\tmp\\hcs403266603" path="\\\\?\\C:\\ProgramData\\docker\\windowsfilter\\2961a824bef1e7df5eedfe4d3e33fde61d6396f0abf0b24601adc418cda42486" hcsshim::ImportLayer - failed failed in Win32: The system can not find the path specified. (0x3)

Fix #86

Thanks flurreN!

Signed-off-by: Takuro Ashie <ashie@clear-code.com>