### PR TITLE
ci: replace with amazonlinux2 container image

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -189,6 +189,8 @@ jobs:
     # approach. Instead, use vagrant on Ubuntu 24.04.
     # (NOTE: nested VM is executable on macos-13, but it is too slow)
     runs-on: ubuntu-24.04
+    container:
+      image: docker.io/amazonlinux:2
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using vagrant for AmazonLinux 2 is troublesome to spin up AL2 VM frequently. It tend to stall network stack.

Instead, directly specify jobs.job_id.container.image. It avoid issues run CGroup v1 container (AL2) on CGroup v2 host (ubuntu-latest).