### PR TITLE
Bump fluent-apt-source version to 2025.7.29

### DIFF
--- a/fluent-apt-source/Rakefile
+++ b/fluent-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2025.1.8"
+    "2025.7.29"
   end
 
   def repository_name

--- a/fluent-lts-apt-source/Rakefile
+++ b/fluent-lts-apt-source/Rakefile
@@ -34,7 +34,7 @@ class FluentdAptLtsSourcePackageTask < PackageTask
   end
 
   def repository_version
-    "2025.1.8"
+    "2025.7.29"
   end
 
   def repository_name


### PR DESCRIPTION
I've forgot to bump version for fluent-apt-source