### PR TITLE
Backport(v6): ci: downgrade glibc version to build a package in AmazonLinux 2023 (#932)

### DIFF
--- a/fluent-package/yum/amazonlinux-2023/Dockerfile
+++ b/fluent-package/yum/amazonlinux-2023/Dockerfile
@@ -27,6 +27,8 @@ RUN \
   yum update -y ${quiet} && \
   yum install -y ${quiet} yum-utils && \
   yum groupinstall -y ${quiet} "Development Tools" && \
+  # Downgrade glibc to 2.34-52 because latest version (2.34-231.amzn2023.0.1) contains glibc 2.35 symbols
+  yum downgrade -y ${quiet} glibc-2.34-52.amzn2023.0.7 glibc-devel-2.34-52.amzn2023.0.7 glibc-headers-x86-2.34-52.amzn2023.0.7 && \
   yum install -y ${quiet} \
     libcap-ng-devel \
     libedit-devel \


### PR DESCRIPTION
Backport https://github.com/fluent/fluent-package-builder/pull/932

Related to
https://github.com/fluent/fluent-package-builder/pull/931#issuecomment-3489640728

This patch will fix following install error on AmazonLinux 2023.
```
   Error:
   Problem: conflicting requests
    - nothing provides libc.so.6(GLIBC_2.35)(64bit) needed by fluent-package-6.0.0-1.amzn2023.x86_64
  (try to add '--skip-broken' to skip uninstallable packages)
```

## Summary
This pull request downgrades the glibc version used in the Amazon Linux 2023 build environment
from **2.34-231.amzn2023.0.1** to **2.34-52.amzn2023.0.7**.

(I just selected same glibc version used in incus container)

## Background
When building `fluent-package` for Amazon Linux 2023, the bundled Ruby gem
[`io-event`](https://rubygems.org/gems/io-event) was compiled against a newer
glibc that provides the `epoll_pwait2()` symbol (introduced in **GLIBC_2.35**).

As a result, the generated package
`fluent-package-6.0.0-1.amzn2023.x86_64.rpm` required `libc.so.6(GLIBC_2.35)`, leading to installation failure on systems still running glibc 2.34.