### PR TITLE
Backport(v6): ci: apply only patch release (#833)

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           cd fluent-package
           gem install bundler:2.3.27
-          bundle _2.3.27_ update -j 4
+          bundle _2.3.27_ update -j 4 --patch
       - name: Create Pull Request
         run: |
           $today=Get-Date -Format "yyyy-MM-dd"


### PR DESCRIPTION
Backport https://github.com/fluent/fluent-package-builder/pull/833

For LTS branch, it should not apply major,minor update in general.