### PR TITLE
Backport(v6): ci: fix empty base_ref error (#831)

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -34,4 +34,4 @@ jobs:
           git add fluent-package/Gemfile.lock
           git commit --message "Update Gemfile.lock" --signoff
           git push origin $branch
-          gh pr create --base ${{ github.base_ref }} --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"
+          gh pr create --base $Env:GITHUB_REF_NAME --title "Update Gemfile.lock" --body "Update Gemfile.lock by maintenance workflow"


### PR DESCRIPTION
Backport https://github.com/fluent/fluent-package-builder/pull/831
Backport https://github.com/fluent/fluent-package-builder/pull/830

## #831
Try to use $Env:GITHUB_REF_NAME which contains branch name

github.base_ref is empty when executing via workflow_dispatch.

## #830
When kicked from LTS branch, base branch should be set explicitly,
otherwise PR will be created against main branch.