### PR TITLE
CHANGELOG: fix fluent-package v5 openssl version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ About the past changelog entries, see [old CHANGELOG](CHANGELOG-v4.md) instead.
 
 * ruby v3.2.9 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.4.0 Windows
+* OpenSSL 3.5.1 Windows
 * OpenSSL 3.0.8 macOS
 * fluentd v1.16.10 (update)
 * msgpack 1.7.5
@@ -76,7 +76,7 @@ On Windows
 
 * ruby v3.2.8 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.4.0 Windows
+* OpenSSL 3.4.1 Windows
 * OpenSSL 3.0.8 macOS
 * fluentd v1.16.9 (update)
 * msgpack 1.7.5
@@ -261,7 +261,7 @@ On Windows
 
 * ruby v3.2.4 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.1.0 Windows
+* OpenSSL 3.3.0 Windows
 * OpenSSL 3.0.8 macOS
 * fluentd v1.16.5
 
@@ -345,7 +345,7 @@ On Windows
 
 * ruby v3.2.3 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.1.0 Windows
+* OpenSSL 3.2.0 Windows
 * OpenSSL 3.0.8 macOS
 * fluentd v1.16.4 (update)
 


### PR DESCRIPTION
I confirm the OpenSSL version bundled with the RubyInstaller for Windows, I discovered an error in the version number listed in the changelog.

Ref. https://github.com/Watson1978/ruby-openssl-version/actions/runs/20088977027