### PR TITLE
CHANGELOG: fix fluent-package v6 openssl version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ On Windows
 
 * ruby v3.4.5 (update)
 * jemalloc v3.6.0
-* OpenSSL 3.4.0 Windows
+* OpenSSL 3.5.1 Windows
 * OpenSSL 3.0.8 macOS
 * gems
   * fluentd v1.19.0 (update)


### PR DESCRIPTION
Same with https://github.com/fluent/fluent-package-builder/pull/944

I confirm the OpenSSL version bundled with the RubyInstaller for Windows, I discovered an error in the version number listed in the changelog.

Ref. https://github.com/Watson1978/ruby-openssl-version/actions/runs/20088977027