### PR TITLE
msi: change ExecutionPolicy to enable it

### DIFF
--- a/fluent-package/msi/assets/fluent-package-post-toast.bat
+++ b/fluent-package/msi/assets/fluent-package-post-toast.bat
@@ -2,6 +2,7 @@
 title Fluent-package post toast script
 if exist "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" (
   if exist "%~dp0..\bin\fluent-package-post-toast.ps1" (
-    "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -File "%~dp0..\bin\fluent-package-post-toast.ps1"
+    "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -File "%~dp0..\bin\fluent-package-post-toast.ps1"
   )
 )
+exit /b 0


### PR DESCRIPTION
In the previous versions, when RemoteSigned was Restricted, it fails
    to execute toast.ps1, thus it causes installation rollback unexpectedly.
    So, it should specify policy of powershell explicitly

Even though execution was disabled via GPO, it just fails but
    always fallback to exit /b 0.
