### PR TITLE
ci: enable ubuntu 26.04 snapshot for testing

### DIFF
--- a/.github/workflows/apt.matrix.json
+++ b/.github/workflows/apt.matrix.json
@@ -28,7 +28,7 @@
       "label": "Ubuntu Resolute amd64",
       "rake-job": "ubuntu-resolute",
       "test-docker-image": "ubuntu:resolute",
-      "test-incus-image": "images:ubuntu/26.04"
+      "test-incus-image": "fluent:ubuntu/26.04"
     }
   ]
 }

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -328,14 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.define-matrix.outputs.matrix).include }}
-        # FIXME: 26.04 incus image is not ready yet
-        exclude:
-          - label: "Ubuntu Resolute amd64"
-            rake-job: "ubuntu-resolute"
-            test-docker-image: "ubuntu:resolute"
-            test-incus-image: "images:ubuntu/26.04"
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -360,14 +353,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.define-matrix.outputs.matrix).include }}
-        # FIXME: 26.04 incus image is not ready yet
-        exclude:
-          - label: "Ubuntu Resolute amd64"
-            rake-job: "ubuntu-resolute"
-            test-docker-image: "ubuntu:resolute"
-            test-incus-image: "images:ubuntu/26.04"
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -395,14 +381,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.define-matrix.outputs.matrix).include }}
-        # FIXME: 26.04 incus image is not ready yet
-        exclude:
-          - label: "Ubuntu Resolute amd64"
-            rake-job: "ubuntu-resolute"
-            test-docker-image: "ubuntu:resolute"
-            test-incus-image: "images:ubuntu/26.04"
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/fluent-package/test-tools/setup-incus.sh
+++ b/fluent-package/test-tools/setup-incus.sh
@@ -8,4 +8,6 @@ sudo apt install -y -V incus
 sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
 sudo iptables -I DOCKER-USER -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 sudo incus admin init --auto
+# enable incus legacy/snapshot images
+sudo incus remote add fluent https://fluentd.cdn.cncf.io/test/incus-images --protocol=simplestreams
 


### PR DESCRIPTION
use fluent:ubuntu/26.04 snapshot in advance for a while.
That will be replaced with linuxcontainer's image later.
