### PR TITLE
deb rpm: set root_dir by default

### DIFF
--- a/fluent-package/templates/etc/fluent/fluentd.conf
+++ b/fluent-package/templates/etc/fluent/fluentd.conf
@@ -8,6 +8,10 @@
     rotate_age 30
   </log>
 </system>
+<% else %>
+<system>
+  root_dir /var/lib/<%= package_dir %>
+</system>
 <% end %>
 
 # Treasure Data (http://www.treasure-data.com/) provides cloud based data

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postinst
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postinst
@@ -36,6 +36,7 @@ add_directories() {
     mkdir -p /etc/<%= package_dir %>/plugin
     mkdir -p /etc/<%= package_dir %>/conf.d
     mkdir -p /var/log/<%= package_dir %>
+    mkdir -p /var/lib/<%= package_dir %>
 }
 
 fixperms() {
@@ -46,6 +47,8 @@ fixperms() {
         dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /etc/<%= package_dir %>
     dpkg-statoverride --list /var/log/<%= package_dir %> >/dev/null || \
         dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/log/<%= package_dir %>
+    dpkg-statoverride --list /var/lib/<%= package_dir %> >/dev/null || \
+        dpkg-statoverride --update --add _<%= service_name %> _<%= service_name %> 0755 /var/lib/<%= package_dir %>
     # Remove obsolete statoverride
     if dpkg-statoverride --list /var/run/<%= compat_package_dir %> >/dev/null; then
         dpkg-statoverride --force-all --remove /var/run/<%= compat_package_dir %>
@@ -55,6 +58,9 @@ fixperms() {
     fi
     if dpkg-statoverride --list /var/log/<%= compat_package_dir %> >/dev/null; then
         dpkg-statoverride --force-all --remove /var/log/<%= compat_package_dir %>
+    fi
+    if dpkg-statoverride --list /var/lib/<%= compat_package_dir %> >/dev/null; then
+        dpkg-statoverride --force-all --remove /var/lib/<%= compat_package_dir %>
     fi
 }
 

--- a/fluent-package/templates/package-scripts/fluent-package/deb/postrm
+++ b/fluent-package/templates/package-scripts/fluent-package/deb/postrm
@@ -42,6 +42,18 @@ purge_var_log() {
 	done
 }
 
+purge_var_lib() {
+	for target_dir in /var/lib/<%= compat_package_dir %> /var/lib/<%= package_dir %>; do
+  	    dpkg-statoverride --list $target_dir > /dev/null && \
+		dpkg-statoverride --remove $target_dir
+	    if [ "$target_dir" = "/var/lib/<%= compat_package_dir %>" ]; then
+		rm -f $target_dir
+	    elif [ "$target_dir" = "/var/lib/<%= package_dir %>" ]; then
+		rm -rf $target_dir
+	    fi
+	done
+}
+
 purge_users() {
 	if getent passwd _<%= service_name %>; then
 	    userdel --remove --force _<%= service_name %>
@@ -84,6 +96,7 @@ case $1 in
 	purge_conf_files
 	purge_var_run
 	purge_var_log
+	purge_var_lib
 	purge_users
 	purge_bin_symlinks
 	purge_working_dir

--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -163,6 +163,7 @@ cd -
 mkdir -p %{buildroot}%{_localstatedir}/run/@PACKAGE_DIR@
 mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@
 mkdir -p %{buildroot}%{_localstatedir}/log/@PACKAGE_DIR@/buffer
+mkdir -p %{buildroot}%{_localstatedir}/lib/@PACKAGE_DIR@
 mkdir -p %{buildroot}%{_sysconfdir}/@PACKAGE_DIR@/plugin
 mkdir -p %{buildroot}%{_sysconfdir}/@PACKAGE_DIR@/conf.d
 mkdir -p %{buildroot}/tmp/@PACKAGE_DIR@
@@ -462,6 +463,7 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/@SERVICE_NAME@
 %config(noreplace) %{_sysconfdir}/@PACKAGE_DIR@/@SERVICE_NAME@.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/@SERVICE_NAME@
+%attr(0755,fluentd,fluentd) %dir %{_localstatedir}/lib/@PACKAGE_DIR@
 %attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@
 %attr(0755,fluentd,fluentd) %dir %{_localstatedir}/log/@PACKAGE_DIR@/buffer
 %attr(0755,fluentd,fluentd) %dir %{_sysconfdir}/@PACKAGE_DIR@


### PR DESCRIPTION
simplify settings and reduce warnings which are related to the use of implicit buffers such as sample plugin.

e.g.

  [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
  [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.