### PR TITLE
Backport(v6) ci: extend build pipeline timeout (#1030)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: .github/workflows/
   build:
     name: Build
-    timeout-minutes: 120
+    timeout-minutes: 180
     needs: define-matrix
     strategy:
       fail-fast: false


### PR DESCRIPTION
As recently resolute was added.