### PR TITLE
ci: use linuxcontainers image

### DIFF
--- a/.github/workflows/apt.matrix.json
+++ b/.github/workflows/apt.matrix.json
@@ -28,7 +28,7 @@
       "label": "Ubuntu Resolute amd64",
       "rake-job": "ubuntu-resolute",
       "test-docker-image": "ubuntu:resolute",
-      "test-incus-image": "fluent:ubuntu/26.04"
+      "test-incus-image": "images:ubuntu/26.04"
     }
   ]
 }

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -212,7 +212,7 @@ jobs:
             container-image: images:ubuntu/24.04
           - label: Ubuntu Resolute amd64
             rake-job: ubuntu-resolute
-            container-image: fluent:ubuntu/26.04
+            container-image: images:ubuntu/26.04
         exclude:
           - label: Debian bookworm amd64
             test: update-from-v4.sh


### PR DESCRIPTION
fluent:ubuntu/26.04 is snapshot image because 26.04 is not ready at that time.

Now resolute image was officially supported, switch to it.