### PR TITLE
CI: fix permission for stale action

### DIFF
--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:


### PR DESCRIPTION
Fix a permission issue where the `stale` action failed to execute due to insufficient permissions. 

Previously, the action resulted in a `Resource not accessible by integration` error when attempting to add labels.

https://github.com/fluent/fluent-package-builder/actions/runs/26397999799/job/77703160526#step:2:122