### PR TITLE
github: fix broken minutes format

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -25,7 +25,7 @@ jobs:
           bundle _2.3.27_ update -j 4
       - name: Create Pull Request
         run: |
-          $today=Get-Date -Format "yyyy-MM-dd-HHMM"
+          $today=Get-Date -Format "yyyy-MM-dd-HHmmss"
           $branch="maintenance/bundle-update/${today}"
 
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Fix broken format which was introduced by #964.

Before: -HHMM means hour-month
After: -HHmmss means hour-minutes-seconds

By adding "seconds" in format, avoid conflict by
sequentially fired actions.