### PR TITLE
Backport(v6) ci: use confluent platform 7.9 (#1057)

### DIFF
--- a/fluent-package/apt/confluent-test.sh
+++ b/fluent-package/apt/confluent-test.sh
@@ -28,10 +28,10 @@ case ${code_name} in
 esac
 
 /usr/sbin/fluent-gem install --no-document serverspec
-wget https://packages.confluent.io/deb/7.6/archive.key
+wget https://packages.confluent.io/deb/7.9/archive.key
 gpg2 --homedir /tmp --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/confluent-archive-keyring.gpg --import archive.key
 chmod 644 /usr/share/keyrings/confluent-archive-keyring.gpg
-echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.6 stable main" > /etc/apt/sources.list.d/confluent.list
+echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.9 stable main" > /etc/apt/sources.list.d/confluent.list
 apt update && apt install -y confluent-community-2.13 ${java_jdk} netcat-openbsd
 
 CONFLUENT_SCRIPT=$(dirname $(realpath $0))/../run-confluent.sh

--- a/fluent-package/yum/confluent-test.sh
+++ b/fluent-package/yum/confluent-test.sh
@@ -46,14 +46,14 @@ ${DNF} install -y \
 fluentd --version
 
 /usr/sbin/fluent-gem install --no-document serverspec
-rpm --import https://packages.confluent.io/rpm/7.6/archive.key
+rpm --import https://packages.confluent.io/rpm/7.9/archive.key
 
 cat <<EOF > /etc/yum.repos.d/confluent.repo
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/7.6
+baseurl=https://packages.confluent.io/rpm/7.9
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/7.6/archive.key
+gpgkey=https://packages.confluent.io/rpm/7.9/archive.key
 enabled=1
 EOF
 ${DNF} update -y && ${DNF} install -y confluent-community-2.13 nmap-ncat


### PR DESCRIPTION
EOL: Feb 19, 2027

https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility