### PR TITLE
Backport(v6) ci: fixup broken mirrors (#1062,#1064)

### DIFF
--- a/fluent-package/yum/systemd-test/common.sh
+++ b/fluent-package/yum/systemd-test/common.sh
@@ -152,3 +152,50 @@ function install_aws_cli()
     unzip awscliv2.zip
     sudo ./aws/install
 }
+
+function fixup_broken_mirrors()
+{
+    if [ "$DISTRIBUTION" = "amazon" ]; then
+        return 0
+    fi
+
+    # When mirrorlist in .repo is not accessible temporary,
+    # CI stops unexpectedly. This is last resort that I hope it will not fire.
+    if ! sudo $DNF repolist -v; then
+        # Avoid broken mirrorlist, enable baseurl explicitly
+        case $DISTRIBUTION_VERSION in
+            8)
+                # install missing dnf-config-manager
+                FALLBACK_URL=https://ftp.iij.ad.jp/pub/linux/rocky
+                sudo $DNF install -y dnf-plugins-core --setopt=baseos.mirrorlist= \
+                     --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/
+
+                sudo $DNF config-manager --setopt=baseos.mirrorlist= \
+                     --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/ --save
+                sudo $DNF config-manager --setopt=appstream.mirrorlist= \
+                     --setopt=appstream.baseurl=${FALLBACK_URL}/\$releasever/AppStream/\$basearch/os/ --save
+                sudo $DNF config-manager --setopt=extras.mirrorlist= \
+                     --setopt=extras.baseurl=${FALLBACK_URL}/\$releasever/extras/\$basearch/os/ --save
+                ;;
+            9|10*)
+                FALLBACK_URL=https://ftp.iij.ad.jp/pub/linux/almalinux
+                sudo $DNF config-manager --setopt=baseos.mirrorlist= \
+                     --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/ --save
+                sudo $DNF config-manager --setopt=appstream.mirrorlist= \
+                     --setopt=appstream.baseurl=${FALLBACK_URL}/\$releasever/AppStream/\$basearch/os/ --save
+                sudo $DNF config-manager --setopt=extras.mirrorlist= \
+                     --setopt=extras.baseurl=${FALLBACK_URL}/\$releasever/extras/\$basearch/os/ --save
+                case $DISTRIBUTION_VERSION in
+                    10*)
+                        sudo $DNF config-manager --setopt=crb.mirrorlist= \
+                         --setopt=crb.baseurl=${FALLBACK_URL}/\$releasever/CRB/\$basearch/os/ --save
+                        ;;
+                esac
+                ;;
+            *)
+                echo "ERROR: unsupported $DISTRIBUTION $DISTRIBUTION_VERSION"
+                exit 1
+                ;;
+        esac
+    fi
+}

--- a/fluent-package/yum/systemd-test/common.sh
+++ b/fluent-package/yum/systemd-test/common.sh
@@ -179,6 +179,9 @@ function fixup_broken_mirrors()
                 ;;
             9|10*)
                 FALLBACK_URL=https://ftp.iij.ad.jp/pub/linux/almalinux
+                sudo $DNF install -y dnf-plugins-core --setopt=baseos.mirrorlist= \
+                     --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/
+
                 sudo $DNF config-manager --setopt=baseos.mirrorlist= \
                      --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/ --save
                 sudo $DNF config-manager --setopt=appstream.mirrorlist= \

--- a/fluent-package/yum/systemd-test/downgrade-to-v4.sh
+++ b/fluent-package/yum/systemd-test/downgrade-to-v4.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 install_v4

--- a/fluent-package/yum/systemd-test/downgrade-to-v5-lts.sh
+++ b/fluent-package/yum/systemd-test/downgrade-to-v5-lts.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 # Install v5 LTS to register the repository

--- a/fluent-package/yum/systemd-test/downgrade-to-v6-lts-tmpfiles.sh
+++ b/fluent-package/yum/systemd-test/downgrade-to-v6-lts-tmpfiles.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 # Display unit info for debug

--- a/fluent-package/yum/systemd-test/elasticsearch.sh
+++ b/fluent-package/yum/systemd-test/elasticsearch.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 GATEWAY=$(ip route | grep default | cut -d' ' -f3)

--- a/fluent-package/yum/systemd-test/install-newly.sh
+++ b/fluent-package/yum/systemd-test/install-newly.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 case $1 in

--- a/fluent-package/yum/systemd-test/obsolete-plugins.sh
+++ b/fluent-package/yum/systemd-test/obsolete-plugins.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 install_current

--- a/fluent-package/yum/systemd-test/opensearch.sh
+++ b/fluent-package/yum/systemd-test/opensearch.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 GATEWAY=$(ip route | grep default | cut -d' ' -f3)

--- a/fluent-package/yum/systemd-test/tmpfiles.sh
+++ b/fluent-package/yum/systemd-test/tmpfiles.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 # Display unit info for debug

--- a/fluent-package/yum/systemd-test/update-from-v4.sh
+++ b/fluent-package/yum/systemd-test/update-from-v4.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 testcase=${1:-directly}

--- a/fluent-package/yum/systemd-test/update-from-v5-lts.sh
+++ b/fluent-package/yum/systemd-test/update-from-v5-lts.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 install_v5_lts

--- a/fluent-package/yum/systemd-test/update-to-next-major-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-major-version.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 service_restart=$1

--- a/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-service-status.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 enabled_before_update=$1 # enabled / disabled

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-auto-and-manual.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-[0-9]*.rpm"

--- a/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version-with-backward-compat-for-v4.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 install_v4

--- a/fluent-package/yum/systemd-test/update-to-next-version.sh
+++ b/fluent-package/yum/systemd-test/update-to-next-version.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 # Install the current

--- a/fluent-package/yum/systemd-test/update-without-data-lost.sh
+++ b/fluent-package/yum/systemd-test/update-without-data-lost.sh
@@ -7,6 +7,8 @@ set -exu
 if [ "$distribution" = "amazon" ]; then
     sudo $DNF repolist -v
     sudo $DNF --releasever=latest update -y
+else
+    fixup_broken_mirrors
 fi
 
 v6_package="/host/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/fluent-package-*.rpm"


### PR DESCRIPTION
There is a case that mirrorlist is not available
form master mirror site.
This is rare case, but it happens.

https://github.com/fluent/fluent-package-builder/actions/runs/26812024181/job/79058336020?pr=1028 
https://github.com/fluent/fluent-package-builder/actions/runs/26812024181/job/79058337196?pr=1028