### PR TITLE
ci: ensure ready to use config-manager

### DIFF
--- a/fluent-package/yum/systemd-test/common.sh
+++ b/fluent-package/yum/systemd-test/common.sh
@@ -179,6 +179,9 @@ function fixup_broken_mirrors()
                 ;;
             9|10*)
                 FALLBACK_URL=https://ftp.iij.ad.jp/pub/linux/almalinux
+                sudo $DNF install -y dnf-plugins-core --setopt=baseos.mirrorlist= \
+                     --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/
+
                 sudo $DNF config-manager --setopt=baseos.mirrorlist= \
                      --setopt=baseos.baseurl=${FALLBACK_URL}/\$releasever/BaseOS/\$basearch/os/ --save
                 sudo $DNF config-manager --setopt=appstream.mirrorlist= \


### PR DESCRIPTION
Follow-up #1062

There was a case that config-manager is not instaled.

https://github.com/fluent/fluent-package-builder/actions/runs/26989986882/job/79648097423