### PR TITLE
ci: switch back windows 2022

### DIFF
--- a/.github/workflows/maintenance-bundle-update.yml
+++ b/.github/workflows/maintenance-bundle-update.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   bundle-update:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
windows-latest was changed to windows-2025, in contrast to that, we use windows-2022 explicitly for windows CI.

Keep it windows-2022 for a while to update Gemfile.lock

(toolchan on windows-2025 was upgraded, it is not confirmed yet.)