### PR TITLE
ci: introduce retry job to make it stable

### DIFF
--- a/.github/workflows/retry-workflows.yml
+++ b/.github/workflows/retry-workflows.yml
@@ -1,0 +1,35 @@
+name: Retry Workflows
+on:
+  workflow_run:
+    workflows:
+      - Apt based Linux
+      - Apt based Linux (AArch64)
+      - Yum based Linux
+      - Yum based Linux (AArch64)
+      - Windows
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  retry:
+    # Retry only twice
+    if: >-
+      contains(
+        fromJSON('["failure", "timed_out"]'),
+        github.event.workflow_run.conclusion
+      ) && github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          echo "(${RUN_ATTEMPT}/2) Re-running failed jobs for run ${RUN_ID}"
+          gh run rerun "${RUN_ID}" --failed


### PR DESCRIPTION
There is a case that workflow jobs are failed time to time.
Reduce manual retry operation, add workflow for it.

NOTE: only execute retry twice.

https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run

