### PR TITLE
yum: keep compatibility with older RHEL 10.x

### DIFF
--- a/.github/workflows/_build_rpm_reusable.yml
+++ b/.github/workflows/_build_rpm_reusable.yml
@@ -52,6 +52,18 @@ jobs:
           else
             echo "Compatibility with GLIBC_ and OPENSSL_ ABI check passed. No incompatible dependencies found."
           fi
+      - name: Ensure RHEL10 compatibility
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit && startsWith(inputs.rake-job, 'almalinux-10') }}
+        run: |
+          if find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
+            ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(4[0-9]|[5-9][0-9])|OPENSSL_3\.[3-9]"; then
+            echo "::error::Incompatible dependencies (GLIBC_2.40, OPENSSL_3.3.0 or later) were detected!"
+            find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
+              ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires
+            exit 1
+          else
+            echo "Compatibility with GLIBC_ and OPENSSL_ API check passed. No incompatible dependencies found."
+          fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ ! steps.cache-rpm.outputs.cache-hit && inputs.next-major }}
         with:

--- a/fluent-package/yum/almalinux-10-aarch64/from
+++ b/fluent-package/yum/almalinux-10-aarch64/from
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arm64v8/almalinux:10
+arm64v8/almalinux:10.0
 

--- a/fluent-package/yum/almalinux-10/Dockerfile
+++ b/fluent-package/yum/almalinux-10/Dockerfile
@@ -16,23 +16,26 @@
 # under the License.
 
 # FIXME: Change from beta version to almalinux:10 later
-ARG FROM=almalinux:10
+ARG FROM=almalinux:10.0
 FROM ${FROM}
 
 COPY qemu-* /usr/bin/
+COPY almalinux-vault-10.0.repo /etc/yum.repos.d/
 
 ARG DEBUG
 
+# Keep compatibility with older RHEL 10.x, hold on specific version
+# not to introduce GLIBC_2.40, OPENSSL_3.3.0, OPENSSL_3.4.0, OPENSSL_3.5.0
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install redhat-release -y && \
   dnf install --enablerepo=crb -y ${quiet} \
     make \
-    gcc-c++ \
-    ruby-devel  \
-    rubygems \
-    rubygem-rake \
-    rubygem-bundler \
+    gcc-c++-14.3.1-4.4.el10.alma.2 \
+    ruby-devel-3.3.8-10.el10_0  \
+    rubygems-3.5.22-10.el10_0 \
+    rubygem-rake-13.1.0-10.el10_0 \
+    rubygem-bundler-2.5.22-10.el10_0 \
     libcap-ng-devel \
     libedit-devel \
     ncurses-devel \
@@ -42,10 +45,11 @@ RUN \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \
     pkg-config \
-    rpm-build \
+    rpm-build-4.19.1.1-12.el10.alma.1 \
     rpmdevtools \
     redhat-rpm-config \
-    openssl-devel \
+    openssl-libs-3.2.2-16.el10_0.4.alma.1 \
+    openssl-devel-3.2.2-16.el10_0.4.alma.1 \
     tar \
     zlib-devel \
     cmake \

--- a/fluent-package/yum/almalinux-10/almalinux-vault-10.0.repo
+++ b/fluent-package/yum/almalinux-10/almalinux-vault-10.0.repo
@@ -1,0 +1,13 @@
+[vault-baseos-10.0]
+name=AlmaLinux 10.0 - BaseOS
+baseurl=https://vault.almalinux.org/10.0/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10
+
+[vault-appstream-10.0]
+name=AlmaLinux 10.0 - AppStream
+baseurl=https://vault.almalinux.org/10.0/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10


### PR DESCRIPTION
yum: keep compatibility with older RHEL 10.x

When building with latest RHEL 10.x, it breaks ABI compatibility with
older RHEL 10.x because it requires GLIBC_2.40.

This is because glibc 2.40 symbols were backported into its glibc 2.39.
It doesn't exist on RHEL 10.1 and earlier version.

Thus build environment should be pinned to 10.0 for keeping
compatibility with all range of RHEL 10.x.
