### PR TITLE
Backport(v6) yum: keep compatibility with older RHEL 9.x (#1087)

### DIFF
--- a/.github/workflows/_build_rpm_reusable.yml
+++ b/.github/workflows/_build_rpm_reusable.yml
@@ -42,6 +42,16 @@ jobs:
         if: ${{ ! steps.cache-rpm.outputs.cache-hit }}
         run: |
           rake yum:build YUM_TARGETS=${{ inputs.rake-job }}
+      - name: Ensure RHEL9 compatibility
+        if: ${{ ! steps.cache-rpm.outputs.cache-hit && startsWith(inputs.rake-job, 'almalinux-9') }}
+        run: |
+          if find fluent-package/yum/repositories -type f -name 'fluent-package-*.rpm' \
+            ! -name '*debug*' ! -name '*.src.rpm' | xargs rpm -qp --requires | grep -qE "GLIBC_2\.(3[6-9]|[4-9][0-9])|OPENSSL_3\.[1-9]"; then
+            echo "::error::Incompatible dependencies (GLIBC_2.36 or later, OPENSSL_3.1.x or later) were detected!"
+            exit 1
+          else
+            echo "Compatibility with GLIBC_ and OPENSSL_ ABI check passed. No incompatible dependencies found."
+          fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ ! steps.cache-rpm.outputs.cache-hit && inputs.next-major }}
         with:

--- a/fluent-package/yum/almalinux-9-aarch64/from
+++ b/fluent-package/yum/almalinux-9-aarch64/from
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arm64v8/almalinux:9
+arm64v8/almalinux:9.2

--- a/fluent-package/yum/almalinux-9/Dockerfile
+++ b/fluent-package/yum/almalinux-9/Dockerfile
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG FROM=almalinux:9
+ARG FROM=almalinux:9.2
 FROM ${FROM}
 
 COPY qemu-* /usr/bin/
+COPY almalinux-vault-9.2.repo /etc/yum.repos.d/almalinux-vault-9.2.repo
 
 ARG DEBUG
 
@@ -27,11 +28,12 @@ RUN \
   dnf install redhat-release -y && \
   dnf install --enablerepo=crb -y ${quiet} \
     make \
-    gcc-c++ \
-    ruby-devel  \
-    rubygems \
-    rubygem-rake \
-    rubygem-bundler \
+    gcc-c++-11.3.1-4.3.el9.alma \
+    glibc-devel-2.34-60.el9_2.7 \
+    ruby-devel-3.0.4-160.el9_0 \
+    rubygems-3.2.33-160.el9_0 \
+    rubygem-rake-13.0.3-160.el9_0 \
+    rubygem-bundler-2.2.33-160.el9_0 \
     libcap-ng-devel \
     libedit-devel \
     ncurses-devel \
@@ -41,10 +43,10 @@ RUN \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \
     pkg-config \
-    rpm-build \
+    rpm-build-4.16.1.3-22.el9 \
     rpmdevtools \
     redhat-rpm-config \
-    openssl-devel \
+    openssl-devel-3.0.7-17.el9_2 \
     tar \
     zlib-devel \
     rpmlint \

--- a/fluent-package/yum/almalinux-9/almalinux-vault-9.2.repo
+++ b/fluent-package/yum/almalinux-9/almalinux-vault-9.2.repo
@@ -1,0 +1,13 @@
+[vault-baseos-9.2]
+name=AlmaLinux 9.2 - BaseOS
+baseurl=https://vault.almalinux.org/9.2/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9
+
+[vault-appstream-9.2]
+name=AlmaLinux 9.2 - AppStream
+baseurl=https://vault.almalinux.org/9.2/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9


### PR DESCRIPTION
When building with latest RHEL 9.x, it breaks ABI compatibility with older RHEL 9.x because it requires GLIBC_2.35 and OPENSSL_3.4.0.

This is because glibc 2.35 symbols were backported into its glibc 2.34. It doesn't exist on RHEL 9.6 and earlier version.

Thus build environment should be pinned to 9.2 for keeping compatibility with all range of RHEL 9.x.

See "Werk #18941: Fix installation failure on AlmaLinux 9 due to GLIBC_2.35 symbol mismatch"
https://checkmk.com/werk/18941