### PR TITLE
rpm: patch release for RHEL 9.x and RHEL 10.x

### DIFF
--- a/fluent-package/yum/fluent-package.spec.in
+++ b/fluent-package/yum/fluent-package.spec.in
@@ -476,6 +476,9 @@ fi
 # NOTE: %{_tmpfilesdir} is available since CentOS 7
 %attr(0755,fluentd,fluentd) %dir /tmp/@PACKAGE_DIR@
 %changelog
+* Mon Jul 13 2026 Kentaro Hayashi <hayashi@clear-code.com> - 6.0.4-2
+- Patch release for RHEL 9.x and RHEL 10.x only
+
 * Fri Jun 26 2026 Kentaro Hayashi <hayashi@clear-code.com> - 6.0.4-1
 - New upstream release.
 

--- a/lib/package-task.rb
+++ b/lib/package-task.rb
@@ -49,7 +49,7 @@ class PackageTask
     else
       @deb_upstream_version = @version
       @rpm_version = @version
-      @rpm_release = "1"
+      @rpm_release = "2"
     end
     @deb_release = "1"
   end


### PR DESCRIPTION
https://github.com/fluent/fluent-package-builder/issues/1086

NOTE: Reset rpm_release in lib/package-task for v6.0.5 